### PR TITLE
Use STABILITY_OUTPUT_DIR to enable file writing

### DIFF
--- a/src/strands_tools/generate_image_stability.py
+++ b/src/strands_tools/generate_image_stability.py
@@ -32,12 +32,8 @@ from strands_tools import generate_image_stability
 os.environ['STABILITY_API_KEY'] = 'sk-xxx'
 os.environ['STABILITY_MODEL_ID'] = 'stability.stable-image-ultra-v1:1'
 
-If you want to save the generated images to disk, set the environment variable `SAVE_IMAGE` to any
-of "true", "yes", "1".
-os.environ['SAVE_IMAGE'] = 'true'
-
-To specify an output directory for saved images, set the environment variable `STABILITY_OUTPUT_DIR`
-to a local directory path.
+If you want to save the generated images to disk, set the environment variable `STABILITY_OUTPUT_DIR`
+to a local directory where the images should be saved.
 
 If no model is selected, the tool defaults to 'stability.stable-image-core-v1:1'.
 
@@ -331,7 +327,7 @@ def generate_image_stability(tool: ToolUse, **kwargs: Any) -> ToolResult:
     Environment Variables:
         STABILITY_API_KEY: Your Stability Platform API key (required)
         STABILITY_MODEL_ID: The model to use (optional, defaults to stability.stable-image-core-v1:1)
-        SAVE_IMAGE: If set to any value (or "true", "yes", "1"), saves generated images to disk
+        STABILITY_OUTPUT_DIR: If set, saves generated images to disk in the specified directory
 
     Args:
         tool: ToolUse object containing the parameters for image generation.
@@ -403,8 +399,8 @@ def generate_image_stability(tool: ToolUse, **kwargs: Any) -> ToolResult:
         filename = None
         save_info = ""
         # Check if we should save the image to a file
-        save_image = os.environ.get("SAVE_IMAGE", "").lower()
-        if save_image in ("true", "yes", "1"):
+        output_dir = os.environ.get("STABILITY_OUTPUT_DIR")
+        if output_dir:
             # Create a unique filename
             import datetime
             import hashlib
@@ -420,7 +416,6 @@ def generate_image_stability(tool: ToolUse, **kwargs: Any) -> ToolResult:
             unique_id = str(uuid.uuid4())[:6]
 
             # Create directory if it doesn't exist
-            output_dir = os.environ.get("STABILITY_OUTPUT_DIR", "stability_images")
             os.makedirs(output_dir, exist_ok=True)
 
             # Construct the filename
@@ -439,9 +434,10 @@ def generate_image_stability(tool: ToolUse, **kwargs: Any) -> ToolResult:
             "source": {"bytes": image_bytes},
         }
 
+        # Disabled until strands-agents/sdk-python#341 is addressed
         # Add filename to the image object if available
-        if filename:
-            image_object["filename"] = filename
+        # if filename:
+        #    image_object["filename"] = filename
 
         return {
             "toolUseId": tool_use_id,

--- a/tests-integ/test_generate_image_stability.py
+++ b/tests-integ/test_generate_image_stability.py
@@ -1,6 +1,7 @@
 import base64
 import os
 import re
+import shutil
 from unittest import mock
 
 import pytest
@@ -25,6 +26,14 @@ def os_environment():
     mock_env = {k: os.environ.get(k) for k in keys_to_copy if k in os.environ}
     with mock.patch.object(os, "environ", mock_env):
         yield mock_env
+
+
+@pytest.fixture
+def test_output_dir():
+    path = "test_stability_output"
+    yield path
+    if os.path.exists(path):
+        shutil.rmtree(path)
 
 
 def test_stability_image_generation_integration():
@@ -150,12 +159,11 @@ def test_stability_error_handling_integration():
     assert "Error generating image" in result["content"][0]["text"]
 
 
-def test_stability_save_feature(os_environment):
+def test_stability_save_feature(os_environment, test_output_dir):
     """
     Test the image saving feature when STABILITY_OUTPUT_DIR is set.
     """
     # Create a test directory for output
-    test_output_dir = "test_stability_output"
     os_environment["STABILITY_OUTPUT_DIR"] = test_output_dir
 
     # Create agent with the tool

--- a/tests-integ/test_generate_image_stability.py
+++ b/tests-integ/test_generate_image_stability.py
@@ -1,6 +1,7 @@
 import base64
 import os
-import shutil
+import re
+from unittest import mock
 
 import pytest
 from strands import Agent
@@ -14,6 +15,17 @@ Export it as an environment variable:
 export STABILITY_API_KEY="your_api_key"
 """
 
+if "STABILITY_API_KEY" not in os.environ:
+    pytest.skip(allow_module_level=True, reason="STABILITY_API_KEY environment variable missing")
+
+
+@pytest.fixture(autouse=True)
+def os_environment():
+    keys_to_copy = ["STABILITY_API_KEY", "STABILITY_MODEL_ID"]
+    mock_env = {k: os.environ.get(k) for k in keys_to_copy if k in os.environ}
+    with mock.patch.object(os, "environ", mock_env):
+        yield mock_env
+
 
 def test_stability_image_generation_integration():
     """
@@ -24,9 +36,6 @@ def test_stability_image_generation_integration():
       - Decode and validate the base64 image
       - Save the output image to a file
     """
-    # Skip if no API key is available
-    if not os.environ.get("STABILITY_API_KEY"):
-        pytest.skip("STABILITY_API_KEY not set - skipping integration test")
 
     # Create agent with the tool
     agent = Agent(tools=[generate_image_stability])
@@ -104,9 +113,6 @@ def test_stability_image_to_image_integration():
     """
     Test image-to-image generation functionality.
     """
-    if not os.environ.get("STABILITY_API_KEY"):
-        pytest.skip("STABILITY_API_KEY not set - skipping integration test")
-
     agent = Agent(tools=[generate_image_stability])
 
     # Create a small test image (1x1 white pixel PNG)
@@ -134,9 +140,6 @@ def test_stability_error_handling_integration():
     """
     Test error handling with invalid inputs.
     """
-    if not os.environ.get("STABILITY_API_KEY"):
-        pytest.skip("STABILITY_API_KEY not set - skipping integration test")
-
     agent = Agent(tools=[generate_image_stability])
 
     # Test with empty prompt (should fail)
@@ -147,129 +150,78 @@ def test_stability_error_handling_integration():
     assert "Error generating image" in result["content"][0]["text"]
 
 
-def test_stability_save_feature():
+def test_stability_save_feature(os_environment):
     """
-    Test the image saving feature when SAVE_IMAGE is enabled.
+    Test the image saving feature when STABILITY_OUTPUT_DIR is set.
     """
-    if not os.environ.get("STABILITY_API_KEY"):
-        pytest.skip("STABILITY_API_KEY not set - skipping integration test")
-
     # Create a test directory for output
     test_output_dir = "test_stability_output"
-    os.environ["STABILITY_OUTPUT_DIR"] = test_output_dir
-    os.environ["SAVE_IMAGE"] = "true"
+    os_environment["STABILITY_OUTPUT_DIR"] = test_output_dir
 
-    # Create directory if it doesn't exist, or clean it if it does
-    if os.path.exists(test_output_dir):
-        print(f"Test output directory {test_output_dir} already exists. Cleaning it up.")
-        # Clean the directory but don't delete it
-        for item in os.listdir(test_output_dir):
-            item_path = os.path.join(test_output_dir, item)
-            if os.path.isfile(item_path):
-                os.unlink(item_path)
-    else:
-        print(f"Creating test output directory: {test_output_dir}")
-        os.makedirs(test_output_dir)
+    # Create agent with the tool
+    agent = Agent(tools=[generate_image_stability])
 
-    try:
-        # Create agent with the tool
-        agent = Agent(tools=[generate_image_stability])
+    # Generate an image
+    prompt = "A test image of a blue circle on a white background"
+    result = agent.tool.generate_image_stability(prompt=prompt)
 
-        # Generate an image
-        prompt = "A test image of a blue circle on a white background"
-        result = agent.tool.generate_image_stability(prompt=prompt)
+    # Verify success
+    assert result["status"] == "success", f"Image generation failed: {result}"
 
-        # Verify success
-        assert result["status"] == "success", f"Image generation failed: {result}"
+    # Verify image content
+    image_content = result["content"][1]
+    assert "image" in image_content
 
-        # Verify image content
-        image_content = result["content"][1]
-        assert "image" in image_content
+    # Verify filename was included in the response
+    text_content = result["content"][0]["text"]
 
-        # Verify filename was included in the response
-        assert "filename" in image_content["image"], "Filename missing from image object"
-        filename = image_content["image"]["filename"]
+    assert "saved to" in text_content.lower(), "Text shouldn't mention saving when disabled"
+    filename = re.search(r"Image saved to (.+\.png)", text_content).group(1)
 
-        # Verify the file exists
-        assert os.path.exists(filename), f"File {filename} was not created"
+    # Verify the file exists
+    assert os.path.exists(filename), f"File {filename} was not created"
 
-        # Verify file contains image data
-        file_size = os.path.getsize(filename)
-        assert file_size > 1000, f"File {filename} seems too small to be a valid image ({file_size} bytes)"
+    # Verify file contains image data
+    file_size = os.path.getsize(filename)
+    assert file_size > 1000, f"File {filename} seems too small to be a valid image ({file_size} bytes)"
 
-        # Verify the text mentions the file was saved
-        text_content = result["content"][0]["text"]
-        assert "saved to" in text_content.lower(), "Text doesn't mention that image was saved"
+    # Verify the text mentions the file was saved
+    text_content = result["content"][0]["text"]
+    assert "saved to" in text_content.lower(), "Text doesn't mention that image was saved"
 
-        # Test that multiple images create different filenames
-        result2 = agent.tool.generate_image_stability(prompt="A bright mural in a columbian town")
-        assert result2["status"] == "success"
+    # Test that multiple images create different filenames
+    result2 = agent.tool.generate_image_stability(prompt="A bright mural in a columbian town")
+    assert result2["status"] == "success"
 
-        filename2 = result2["content"][1]["image"]["filename"]
-        assert filename != filename2, "Multiple images should have different filenames"
-        assert os.path.exists(filename2)
+    filename2 = re.search(r"Image saved to (.+\.png)", result2["content"][0]["text"]).group(1)
+    assert filename != filename2, "Multiple images should have different filenames"
+    assert os.path.exists(filename2)
 
-        # Verify filenames follow expected pattern
-        import re
-
-        filename_pattern = re.compile(r"\d{8}_\d{6}_[a-f0-9]{8}_[a-f0-9]{6}\.png$")
-        assert filename_pattern.search(filename), f"Filename {filename} doesn't match expected pattern"
-
-    finally:
-        # Clean up - remove the test directory
-        if os.path.exists(test_output_dir):
-            shutil.rmtree(test_output_dir)
-
-        # Reset environment variables
-        os.environ.pop("STABILITY_OUTPUT_DIR", None)
-        os.environ.pop("SAVE_IMAGE", None)
+    # Verify filenames follow expected pattern
+    filename_pattern = re.compile(r"\d{8}_\d{6}_[a-f0-9]{8}_[a-f0-9]{6}\.png$")
+    assert filename_pattern.search(filename), f"Filename {filename} doesn't match expected pattern"
 
 
 def test_stability_save_disabled():
     """
-    Test that images are not saved when SAVE_IMAGE is not set.
+    Test that images are not saved when STABILITY_OUTPUT_DIR is not set.
     """
-    if not os.environ.get("STABILITY_API_KEY"):
-        pytest.skip("STABILITY_API_KEY not set - skipping integration test")
 
-    # Ensure SAVE_IMAGE is not set
-    if "SAVE_IMAGE" in os.environ:
-        del os.environ["SAVE_IMAGE"]
+    # Create agent with the tool
+    agent = Agent(tools=[generate_image_stability])
 
-    # Set a test directory that we'll check doesn't get created
-    test_output_dir = "test_stability_disabled_output"
-    os.environ["STABILITY_OUTPUT_DIR"] = test_output_dir
+    # Generate an image
+    result = agent.tool.generate_image_stability(prompt="A test image when saving is disabled")
 
-    try:
-        # Create agent with the tool
-        agent = Agent(tools=[generate_image_stability])
+    # Verify success
+    assert result["status"] == "success", f"Image generation failed: {result}"
 
-        # Generate an image
-        result = agent.tool.generate_image_stability(prompt="A test image when saving is disabled")
+    # Verify image content exists
+    image_content = result["content"][1]
+    assert "image" in image_content
 
-        # Verify success
-        assert result["status"] == "success", f"Image generation failed: {result}"
+    print(">>>>>>>>>>>>>text content:", result["content"][0])
 
-        # Verify image content exists
-        image_content = result["content"][1]
-        assert "image" in image_content
-
-        print(">>>>>>>>>>>>>text content:", result["content"][0])
-
-        # Verify filename was not included
-        assert "filename" not in image_content["image"], "Filename should not be present when saving is disabled"
-
-        # Verify the directory was not created
-        assert not os.path.exists(test_output_dir), f"Directory {test_output_dir} should not have been created"
-
-        # Verify the text doesn't mention saving image to disk
-        text_content = result["content"][0]["text"]
-        assert "saved to" not in text_content.lower(), "Text shouldn't mention saving when disabled"
-
-    finally:
-        # Clean up
-        if os.path.exists(test_output_dir):
-            shutil.rmtree(test_output_dir)
-
-        # Reset environment variable
-        os.environ.pop("STABILITY_OUTPUT_DIR", None)
+    # Verify the text doesn't mention saving image to disk
+    text_content = result["content"][0]["text"]
+    assert "saved to" not in text_content.lower(), "Text shouldn't mention saving when disabled"


### PR DESCRIPTION
Small tweaks to the tool to better work across providers with strands:

 - Use `STABILITY_OUTPUT_DIR` as the only environment variable needed to enable file writing
 - Do not write the `filename` in the output, as it crashes on bedrock (strands-agents/sdk-python#341)

I had to update the tests as part of these changes and while doing so:
 - ignored all tests at the top level if the STABILITY_API_KEY isn't present
 - used a mocked os.environ to avoid modifying the global one